### PR TITLE
Fix Windows when both `Path` and `PATH` are defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const pathKey = (options = {}) => {
 		return 'PATH';
 	}
 
-	return Object.keys(environment).find(key => key.toUpperCase() === 'PATH') || 'Path';
+	return Object.keys(environment).reverse().find(key => key.toUpperCase() === 'PATH') || 'Path';
 };
 
 module.exports = pathKey;

--- a/test.js
+++ b/test.js
@@ -7,4 +7,6 @@ test('main', t => {
 	t.is(pathKey({env: {Path: ''}, platform: 'win32'}), 'Path');
 	t.is(pathKey({env: {}, platform: 'darwin'}), 'PATH');
 	t.is(pathKey({env: {}, platform: 'win32'}), 'Path');
+	t.is(pathKey({env: {Path: '', PATH: ''}, platform: 'win32'}), 'PATH');
+	t.is(pathKey({env: {PATH: '', Path: ''}, platform: 'win32'}), 'Path');
 });


### PR DESCRIPTION
Environment variables are case-sensitive on Unix. However on Windows, they are case-insensitive. When the same environment variable is defined twice but with different cases, the last one prevails.

For example:

```js
child_process.execSync("node -p process.env.Path", { 
  env: { Path: 'C:', PATH: 'D:' }, 
  encoding: "utf8", 
  stdio: "inherit", 
})
```

prints `D:` on Windows. What happens is: Node.js takes the value of the last defined property (`PATH`) and uses it for both `Path` and `PATH` in the child process.

`path-key` currently looks up environment variables in normal order. This means, if both `Path` and `PATH` are defined, it returns `Path`. However `child_process.spawn()` would actually discard `Path` and only use `PATH` (since it is defined last in the object properties order).

This leads to the `preferLocal` and `execPath` options not working at all with [Execa](https://github.com/sindresorhus/execa) when on Windows and both `Path` and `PATH` are defined by the environment. In such cases, those options are noop.

Note that Travis CI Windows environment has both `Path` and `PATH` defined, so this is quite common in real life.

This PR fixes this issue by looking up environment variables in reverse order instead. I checked it against real-life examples, and also added unit tests.