### PR TITLE
Upgrade Node version and `devDependencies`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,11 +10,11 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 14
-          - 12
+          - 22
+          - 18
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-export interface Options {
+export type Options = {
 	/**
 	Use a custom environment variables object.
 
@@ -12,7 +12,7 @@ export interface Options {
 	Default: [`process.platform`](https://nodejs.org/api/process.html#process_process_platform).
 	*/
 	readonly platform?: NodeJS.Platform;
-}
+};
 
 /**
 Get the [PATH](https://en.wikipedia.org/wiki/PATH_(variable)) environment variable key cross-platform.

--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
+import process from 'node:process';
+
 export default function pathKey(options = {}) {
 	const {
 		env = process.env,
-		platform = process.platform
+		platform = process.platform,
 	} = options;
 
 	if (platform !== 'win32') {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	"type": "module",
 	"exports": "./index.js",
 	"engines": {
-		"node": ">=12"
+		"node": ">=18"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"
@@ -33,9 +33,9 @@
 		"windows"
 	],
 	"devDependencies": {
-		"@types/node": "^14.14.37",
-		"ava": "^3.15.0",
-		"tsd": "^0.14.0",
-		"xo": "^0.38.2"
+		"@types/node": "^20.12.8",
+		"ava": "^6.1.2",
+		"tsd": "^0.31.0",
+		"xo": "^0.58.0"
 	}
 }


### PR DESCRIPTION
This PR runs the CI on Node 22 and upgrades the development dependencies.

This also drops support for Node 12, 14 and 16.